### PR TITLE
FuelPickUpDebugging

### DIFF
--- a/Assets/Scenes/FuelTest.unity
+++ b/Assets/Scenes/FuelTest.unity
@@ -1,0 +1,311 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+SceneSettings:
+  m_ObjectHideFlags: 0
+  m_PVSData: 
+  m_PVSObjectsArray: []
+  m_PVSPortalsArray: []
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 7
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 7
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_TemporalCoherenceThreshold: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 4
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_TextureWidth: 1024
+    m_TextureHeight: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_DirectLightInLightProbes: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+  m_LightingDataAsset: {fileID: 0}
+  m_RuntimeCPUUsage: 25
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    accuratePlacement: 0
+    minRegionArea: 2
+    cellSize: 0.16666667
+    manualCellSize: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &974732342
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 974732347}
+  - 20: {fileID: 974732346}
+  - 92: {fileID: 974732345}
+  - 124: {fileID: 974732344}
+  - 81: {fileID: 974732343}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &974732343
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 974732342}
+  m_Enabled: 1
+--- !u!124 &974732344
+Behaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 974732342}
+  m_Enabled: 1
+--- !u!92 &974732345
+Behaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 974732342}
+  m_Enabled: 1
+--- !u!20 &974732346
+Camera:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 974732342}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 20
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+  m_StereoMirrorMode: 0
+--- !u!4 &974732347
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 974732342}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+--- !u!1 &1132927257 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1000014294361950, guid: 7ae77bbf9d029c145a4ca6d1c0f6a7f0,
+    type: 2}
+  m_PrefabInternal: {fileID: 1429799314}
+--- !u!114 &1132927262
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1132927257}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 405aef21f13ff1e48ab9aa6ea25fc192, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  drift: 0
+  rotateActivated: 0
+  splitactivated: 0
+  objectSize: 5
+  splitter: {fileID: 0}
+  splitterShard: {fileID: 0}
+  splitterX: 0
+  splitterY: 0
+  knockBackImpact: 500
+  isTractored: 0
+  angleCollisionDamage: 0
+--- !u!50 &1132927263
+Rigidbody2D:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1132927257}
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!1001 &1429799314
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4000012249292780, guid: 7ae77bbf9d029c145a4ca6d1c0f6a7f0, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: -6.340123
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000012249292780, guid: 7ae77bbf9d029c145a4ca6d1c0f6a7f0, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: -0.5328983
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000012249292780, guid: 7ae77bbf9d029c145a4ca6d1c0f6a7f0, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000012249292780, guid: 7ae77bbf9d029c145a4ca6d1c0f6a7f0, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000012249292780, guid: 7ae77bbf9d029c145a4ca6d1c0f6a7f0, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000012249292780, guid: 7ae77bbf9d029c145a4ca6d1c0f6a7f0, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000012249292780, guid: 7ae77bbf9d029c145a4ca6d1c0f6a7f0, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000012249292780, guid: 7ae77bbf9d029c145a4ca6d1c0f6a7f0, type: 2}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1000014294361950, guid: 7ae77bbf9d029c145a4ca6d1c0f6a7f0, type: 2}
+      propertyPath: m_TagString
+      value: Fuel
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 7ae77bbf9d029c145a4ca6d1c0f6a7f0, type: 2}
+  m_IsPrefabParent: 0
+--- !u!1001 &1917588559
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4000012033981452, guid: b0b7fba286815dc44b0ba11b680392c4, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 4.3931994
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000012033981452, guid: b0b7fba286815dc44b0ba11b680392c4, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: -0.9024789
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000012033981452, guid: b0b7fba286815dc44b0ba11b680392c4, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000012033981452, guid: b0b7fba286815dc44b0ba11b680392c4, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000012033981452, guid: b0b7fba286815dc44b0ba11b680392c4, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000012033981452, guid: b0b7fba286815dc44b0ba11b680392c4, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000012033981452, guid: b0b7fba286815dc44b0ba11b680392c4, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000012033981452, guid: b0b7fba286815dc44b0ba11b680392c4, type: 2}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: b0b7fba286815dc44b0ba11b680392c4, type: 2}
+  m_IsPrefabParent: 0

--- a/Assets/Scenes/FuelTest.unity.meta
+++ b/Assets/Scenes/FuelTest.unity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f0a28bf19ba6bec4a89ea5bf15cbf0c7
+timeCreated: 1477953410
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -84,11 +84,11 @@ public class Player : MonoBehaviour {
     public Vector2 asteroidDirection;
     //shield script in child object
     PlayerShield shield;
-
+    public bool _fuelControl;
     // Use this for initialization
     void Start () 
 	{
-
+        _fuelControl = true;
         maxXBoundary *= unit;
         maxYBoundary *= unit;
         minXBoundary *= unit;
@@ -117,7 +117,15 @@ public class Player : MonoBehaviour {
 	{
 		//Function to handle player movement
 		ControlPlayer();
-        LoseFuel();
+        if (_fuelControl)
+        {
+            LoseFuel(); //By default, lose fuel
+        }
+        else
+        {
+            gainFuel(); //When _fuelControl is false, gain fuel instead
+        }
+            
 		checkIfPlayerOutOfBounds(maxXBoundary, maxYBoundary, minXBoundary, minYBoundary);
 
 		// The health regen will only occur when we are below max health
@@ -336,11 +344,12 @@ public class Player : MonoBehaviour {
 	}
 
     //function for adding onto the player's current fuel
-    public void gainFuel(int num)
+    public void gainFuel()
     {
-        currentFuel += num;
-
-        if (currentFuel > MAX_FUEL)
+        Debug.Log("Your current fuel amount is increasing = " + currentFuel);
+        currentFuel += Time.deltaTime*5;
+        
+        if (currentFuel > MAX_FUEL) //Keeps the current fuel from passing the cap
         {
             currentFuel = MAX_FUEL;
         }
@@ -348,15 +357,16 @@ public class Player : MonoBehaviour {
     }
 
     //function that decreases the Player's fuel
-    //decreases faster when moving
      void LoseFuel()
      {
-        if(rb2d.velocity.magnitude < 2)
+        if(rb2d.velocity.magnitude < 3)
         {
+            Debug.Log("Your current fuel amount is = " + currentFuel);
             currentFuel -= Time.deltaTime;
         }
         else
         {
+            Debug.Log("Your current fuel amount is depleting rapidly = " + currentFuel); //decreases faster when moving
             currentFuel -= Time.deltaTime*1.5f;
         }
      }

--- a/Assets/Scripts/TractorBeamControls.cs
+++ b/Assets/Scripts/TractorBeamControls.cs
@@ -21,6 +21,10 @@ public class TractorBeamControls : MonoBehaviour
     private const float MAX_TRACTOR_LENGTH = 15;
     private const float MAX_TRACTOR_PUSH = 20;
 
+    private GameObject _player;
+    private Player _playerCont;
+    
+
     //PLAYER COMPONENTS
     private LineRenderer _tractorLine;
 
@@ -37,6 +41,9 @@ public class TractorBeamControls : MonoBehaviour
     // Use this for initialization
     void Start()
     {
+        _player = GameObject.FindGameObjectWithTag("Player");   //References the player object
+        _playerCont = _player.GetComponent<Player>(); //References the playerscript
+
         _tractorLine = GetComponent<LineRenderer>();
         
         
@@ -93,6 +100,11 @@ public class TractorBeamControls : MonoBehaviour
                     _hitDebris = true;
                     
                    
+                }
+                if(_tractorStick.collider.CompareTag("Fuel"))
+                {
+                    //Activates Fuel Gain
+                    _playerCont._fuelControl = false;
                 }
             }
 
@@ -199,7 +211,12 @@ public class TractorBeamControls : MonoBehaviour
                 objectScript = null;
                 _hitDebris = false;
                 _tractorlength = 0;
+
+            if(_playerCont._fuelControl == false) //When the player stops gaining fuel, restore fuel loss to default
+            {
+                _playerCont._fuelControl = true;
             }
+        }
 
 
 
@@ -426,7 +443,7 @@ public class TractorBeamControls : MonoBehaviour
         //Debug.Log("Hit");
         if (collision.collider == _tractorStick.collider)
         {
-            Debug.Log("hit myself");
+            //Debug.Log("hit myself");
             hitMyself = true;
         }
     }


### PR DESCRIPTION
-Fuel Test Scene added
-Several debug.log statements added for testing purposes. Please remove when done.

-Tractor Beam References player script, when a fuel prefab is "tractored", the player object stops losing fuel and starts gaining fuel
instead. When the tractor beam is released, the player will resume fuel loss as normal.

-Player script update() method is modifed to include an if-statement that can swap between losing and gaining fuel

-Attached Rigidbody and movableobject script to Fuel prefab. Works without, but looks awkward since the tractor beam won't hook on
otherwise.